### PR TITLE
ppng.ml → ppng.io

### DIFF
--- a/localfiles/.zshrc.local
+++ b/localfiles/.zshrc.local
@@ -34,17 +34,17 @@ link='link_you_want'
 function send()
 {
 	if test $# -eq 0; then
-		command curl -k -T - https://ppng.ml/$link
+		command curl -k -T - https://ppng.io/$link
 	else
-		command curl -k -T $1 https://ppng.ml/$link
+		command curl -k -T $1 https://ppng.io/$link
 	fi
 }
 
 function recv()
 {
 	if test $# -eq 0; then
-		command curl -k https://ppng.ml/$link
+		command curl -k https://ppng.io/$link
 	else
-		command curl -k https://ppng.ml/$link -o $1
+		command curl -k https://ppng.io/$link -o $1
 	fi
 }


### PR DESCRIPTION
はじめまして。

ppng.ml を管理していた者です。元々フリードメインだった ppng.ml のドメインが有料になり ppng.ml を使用しなくなりました。その代わりに現在は別の有料の ppng.io のドメインで管理し続けています。そのため ppng.io に変更させていただきました。ppng.io も ppng.ml と同じサーバーに向いています。